### PR TITLE
Use walkRecursive inside findPartials

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -163,13 +163,9 @@ utils.wrap = function (template, options) {
 function findPartials(fragment) {
 	var found = [];
 
-	_.forEach(fragment.t, function (item) {
+	walkRecursive(fragment.t, function(item) {
 		if (item.t === 8) {
 			found.push(item.r);
-		}
-
-		if (_.isArray(item.f)) {
-			found = found.concat(findPartials(item.f));
 		}
 	});
 

--- a/test/samples/load/template-partial-nested.html
+++ b/test/samples/load/template-partial-nested.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}!</p><p>{{>partial}}</p>

--- a/test/samples/rvc/template-partial-nested.html
+++ b/test/samples/rvc/template-partial-nested.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}!</p><p>{{>partial}}</p>

--- a/test/samples/template/template-partial-nested.html
+++ b/test/samples/template/template-partial-nested.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}!</p><p>{{>partial}}</p>

--- a/test/tests/load.js
+++ b/test/tests/load.js
@@ -151,6 +151,16 @@ describe('load', function () {
 					});
 				});
 
+				it('should autoload the partial rendered inside another element', function(done) {
+					app.render('template/template-partial-nested.html', { data: { name: 'Word' } }, function(err, html) {
+						if (err) {
+							done(err);
+						}
+
+						expect(html).to.equal('<p>Hello Word!</p><p>Hi there!</p>');
+					});
+				});
+
 				it('should allow the default partial to be overridden', function (done) {
 					app.render('load/template-partial-2.html', { data: { name: 'Word' } }, function (err, html) {
 						if (err) {

--- a/test/tests/rvc.js
+++ b/test/tests/rvc.js
@@ -151,6 +151,16 @@ describe('rvc', function () {
 					});
 				});
 
+				it('should autoload the partial rendered inside another element', function(done) {
+					app.render('template/template-partial-nested.html', { data: { name: 'Word' } }, function(err, html) {
+						if (err) {
+							done(err);
+						}
+
+						expect(html).to.equal('<p>Hello Word!</p><p>Hi there!</p>');
+					});
+				});
+
 				it('should allow the default partial to be overridden', function (done) {
 					app.render('rvc/template-partial-2.html', { data: { name: 'Word' } }, function (err, html) {
 						if (err) {

--- a/test/tests/template.js
+++ b/test/tests/template.js
@@ -140,6 +140,16 @@ describe('template', function () {
 					});
 				});
 
+				it('should autoload the partial rendered inside another element', function(done) {
+					app.render('template/template-partial-nested.html', { data: { name: 'Word' } }, function(err, html) {
+						if (err) {
+							done(err);
+						}
+
+						expect(html).to.equal('<p>Hello Word!</p><p>Hi there!</p>');
+					});
+				});
+
 				it('should not fail if partial doesn\'t exist', function (done) {
 					app.render('template/template-no-partial.html', { data: { name: 'Word' } }, function (err, html) {
 						if (err) {


### PR DESCRIPTION
`findPartials` was not correctly recursing into the ractive fragment correctly. This was causing partials placed under parent elements not to be found, e.g. `partial` would not be found in this use case:

```
<p>{{>partial}}</p>
```

I've refactored `findPartials` to use the `walkRecursive` function, like `injectTemplate` does.

I added a test, but could not get the suite passing. There are many errors of the form:

```
no such file or directory '/Users/blake/Developer/ractive-render/test/samples/rvc/template'
```

The missing `.html` extension smells like a bug somewhere in rvc / requirejs.
