### PR TITLE
Teardown components after render to prevent leaking

### DIFF
--- a/lib/ractive-render.js
+++ b/lib/ractive-render.js
@@ -122,7 +122,13 @@ rr.renderFile = function (file, options, callback) {
 		return rr.loaders[options.use](file, options).then(function (Component) {
 			options.data = options.data || options;
 
-			return new Component(options).toHTML();
+			var component = new Component( options );
+			var html = component.toHTML();
+									
+			component.teardown();
+									
+			return html;
+			
 		});
 	}).nodeify(callback);
 };


### PR DESCRIPTION
Using ractive-render to fuel SEO requirements. When rendering components they were leaking after returning .toHTML().   Calling .teardown() destroys them.
